### PR TITLE
Allow longer statusComment in auditeeResponse validation

### DIFF
--- a/app/Http/Controllers/ExceptionApprovalController.php
+++ b/app/Http/Controllers/ExceptionApprovalController.php
@@ -729,7 +729,7 @@ class ExceptionApprovalController extends Controller
                 'exceptionItemId' => 'required|integer',
                 'status' => 'required|string',
                 // 'push_bak_status' => 'required|string',
-                'statusComment' => 'required|string|max:255',
+                'statusComment' => 'required|string',
             ]);
 
             // dd($validatedData);


### PR DESCRIPTION
Remove the 'max:255' rule from the 'statusComment' validator in ExceptionApprovalController::auditeeResponse so auditees can submit comments longer than 255 characters without being rejected by validation.